### PR TITLE
feat: add /api/tx/external endpoint for sending transactional emails to external recipients

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -179,6 +179,7 @@ func initHTTPHandlers(e *echo.Echo, a *App) {
 		g.DELETE("/api/maintenance/subscriptions/unconfirmed", pm(a.GCSubscriptions, "settings:maintain"))
 
 		g.POST("/api/tx", pm(a.SendTxMessage, "tx:send"))
+		g.POST("/api/tx/external", pm(a.SendExternalTxMessage, "tx:send"))
 
 		g.GET("/api/profile", a.GetUserProfile)
 		g.PUT("/api/profile", a.UpdateUserProfile)

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -202,3 +202,140 @@ func (a *App) validateTxMessage(m models.TxMessage) (models.TxMessage, error) {
 
 	return m, nil
 }
+
+// SendExternalTxMessage handles the sending of a transactional message to external email addresses.
+func (a *App) SendExternalTxMessage(c echo.Context) error {
+	var m models.TxMessage
+
+	// If it's a multipart form, there may be file attachments.
+	if strings.HasPrefix(c.Request().Header.Get("Content-Type"), "multipart/form-data") {
+		form, err := c.MultipartForm()
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest,
+				a.i18n.Ts("globals.messages.invalidFields", "name", err.Error()))
+		}
+
+		data, ok := form.Value["data"]
+		if !ok || len(data) != 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, a.i18n.Ts("globals.messages.invalidFields", "name", "data"))
+		}
+
+		// Parse the JSON data.
+		if err := json.Unmarshal([]byte(data[0]), &m); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest,
+				a.i18n.Ts("globals.messages.invalidFields", "name", fmt.Sprintf("data: %s", err.Error())))
+		}
+
+		// Attach files.
+		for _, f := range form.File["file"] {
+			file, err := f.Open()
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError,
+					a.i18n.Ts("globals.messages.invalidFields", "name", fmt.Sprintf("file: %s", err.Error())))
+			}
+			defer file.Close()
+
+			b, err := io.ReadAll(file)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError,
+					a.i18n.Ts("globals.messages.invalidFields", "name", fmt.Sprintf("file: %s", err.Error())))
+			}
+
+			m.Attachments = append(m.Attachments, models.Attachment{
+				Name:    f.Filename,
+				Header:  manager.MakeAttachmentHeader(f.Filename, "base64", f.Header.Get("Content-Type")),
+				Content: b,
+			})
+		}
+
+	} else if err := c.Bind(&m); err != nil {
+		return err
+	}
+
+	// Validate fields.
+	if r, err := a.validateExternalTxMessage(m); err != nil {
+		return err
+	} else {
+		m = r
+	}
+
+	// Get the cached tx template.
+	tpl, err := a.manager.GetTpl(m.TemplateID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			a.i18n.Ts("globals.messages.notFound", "name", fmt.Sprintf("template %d", m.TemplateID)))
+	}
+
+	// Create a dummy subscriber for template rendering.
+	dummySub := models.Subscriber{
+		Email: m.SubscriberEmails[0],
+		Name:  m.SubscriberEmails[0],
+	}
+
+	// Render the message.
+	if err := m.Render(dummySub, tpl); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			a.i18n.Ts("globals.messages.errorFetching", "name"))
+	}
+
+	// Prepare the final message.
+	msg := models.Message{}
+	msg.To = m.SubscriberEmails
+	msg.From = m.FromEmail
+	msg.Subject = m.Subject
+	msg.ContentType = m.ContentType
+	msg.Messenger = m.Messenger
+	msg.Body = m.Body
+	for _, a := range m.Attachments {
+		msg.Attachments = append(msg.Attachments, models.Attachment{
+			Name:    a.Name,
+			Header:  a.Header,
+			Content: a.Content,
+		})
+	}
+
+	// Optional headers.
+	if len(m.Headers) != 0 {
+		msg.Headers = make(textproto.MIMEHeader, len(m.Headers))
+		for _, set := range m.Headers {
+			for hdr, val := range set {
+				msg.Headers.Add(hdr, val)
+			}
+		}
+	}
+
+	if err := a.manager.PushMessage(msg); err != nil {
+		a.log.Printf("error sending message (%s): %v", msg.Subject, err)
+		return err
+	}
+
+	return c.JSON(http.StatusOK, okResp{true})
+}
+
+// validateExternalTxMessage validates the external tx message fields.
+func (a *App) validateExternalTxMessage(m models.TxMessage) (models.TxMessage, error) {
+	if len(m.SubscriberEmails) == 0 {
+		return m, echo.NewHTTPError(http.StatusBadRequest,
+			a.i18n.Ts("globals.messages.invalidFields", "name", "subscriber_emails is required"))
+	}
+
+	for n, email := range m.SubscriberEmails {
+		em, err := a.importer.SanitizeEmail(email)
+		if err != nil {
+			return m, echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
+		m.SubscriberEmails[n] = em
+	}
+
+	if m.FromEmail == "" {
+		m.FromEmail = a.cfg.FromEmail
+	}
+
+	if m.Messenger == "" {
+		m.Messenger = emailMsgr
+	} else if !a.manager.HasMessenger(m.Messenger) {
+		return m, echo.NewHTTPError(http.StatusBadRequest, a.i18n.Ts("campaigns.fieldInvalidMessenger", "name", m.Messenger))
+	}
+
+	return m, nil
+}

--- a/docs/swagger/collections.yaml
+++ b/docs/swagger/collections.yaml
@@ -1912,16 +1912,39 @@ paths:
 
   /tx:
     post:
+      description: handles sending of transactional message to a subscriber
+      operationId: sendTxMessage
       tags:
         - Transactional
-      description: send message to a subscriber
-      operationId: transactWithSubscriber
       requestBody:
         description: email message to a subscriber
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/TransactionalMessage"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: boolean
+
+  /tx/external:
+    post:
+      description: handles sending of transactional message to any email address without requiring the recipient to be a subscriber
+      operationId: sendExternalTxMessage
+      tags:
+        - Transactional
+      requestBody:
+        description: email message to external recipients
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExternalTransactionalMessage"
       responses:
         "200":
           description: OK
@@ -4079,3 +4102,36 @@ components:
           type: string
         content_type:
           type: string
+
+    ExternalTransactionalMessage:
+      type: object
+      required:
+        - subscriber_emails
+        - template_id
+        - subject
+      properties:
+        subscriber_emails:
+          type: array
+          items:
+            type: string
+          description: List of email addresses to send the message to
+        template_id:
+          type: integer
+          description: ID of the template to use
+        subject:
+          type: string
+          description: Subject of the email
+        data:
+          type: object
+          description: Optional data to be used in the template
+        attachments:
+          type: array
+          items:
+            type: object
+            properties:
+              filename:
+                type: string
+              content:
+                type: string
+                format: binary
+          description: Optional file attachments


### PR DESCRIPTION
This pull request introduces a new feature to support sending transactional messages to external email addresses (non-subscribers). Key changes include adding a new API endpoint, implementing the handler logic, and updating the API documentation to reflect these enhancements.

### New API Endpoint for External Transactional Messages:

* **Handler Implementation**: Added the `SendExternalTxMessage` function in `cmd/tx.go` to handle sending transactional messages to external email addresses. This includes parsing multipart form data, validating fields, rendering templates, and pushing messages to the message queue.
* **Route Registration**: Registered the new endpoint `/api/tx/external` in `cmd/handlers.go` with the corresponding handler and permission middleware.

### API Documentation Updates:

* **New Endpoint Documentation**: Added `/tx/external` to the Swagger documentation in `docs/swagger/collections.yaml`, including its description, request body schema, and response format.
* **Schema Definition**: Defined a new schema, `ExternalTransactionalMessage`, in the Swagger documentation to describe the structure of the request payload for the new endpoint.

### Minor Updates:

* **Existing Endpoint Documentation**: Updated the description and operation ID for the existing `/tx` endpoint in the Swagger documentation for clarity.